### PR TITLE
fix dict.keys() subscript error in python 3+

### DIFF
--- a/src/get_target_ids
+++ b/src/get_target_ids
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         compounds2targets[chembl] = set()
 
     chunk_size = 50
-    keys = compounds2targets.keys()
+    keys = list(compounds2targets.keys())
 
     ID_forms = dict()
     for x in keys:


### PR DESCRIPTION
Example code in the README doesn't work with python 3.6.

```python
Traceback (most recent call last):
  File "src/get_target_ids", line 42, in <module>
    for form in new_client.molecule_form.filter(parent_chembl_id__in=keys[i:i + chunk_size]):
TypeError: 'dict_keys' object is not subscriptable
```